### PR TITLE
Add missing Stream destroy method

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,11 @@ exports.parse = function (path) {
     stream.emit('root', stream.root, count)
     stream.emit('end')
   }
+
+  stream.destroy = function () {
+    stream.emit('close');
+  }
+
   return stream
 }
 

--- a/test/destroy_missing.js
+++ b/test/destroy_missing.js
@@ -1,0 +1,22 @@
+var fs = require ('fs');
+var net = require('net');
+var join = require('path').join;
+var file = join(__dirname, 'fixtures','all_npm.json');
+var JSONStream = require('../');
+
+
+var server = net.createServer(function(client) {
+    var parser = JSONStream.parse([]);
+    parser.on('close', function() {
+        console.error('PASSED');
+        server.close();
+    });
+    client.pipe(parser);
+    client.destroy();
+});
+server.listen(9999);
+
+
+var client = net.connect({ port : 9999 }, function() {
+    fs.createReadStream(file).pipe(client);
+});


### PR DESCRIPTION
With the new test case, I was receiving this error:

stream.js:74
    dest.destroy();
         ^
TypeError: Object #<Stream> has no method 'destroy'
    at Socket.onclose (stream.js:74:10)
    at Socket.EventEmitter.emit (events.js:115:20)
    at Socket._destroy.destroyed (net.js:356:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)

After adding the destroy method the test passes
