### PR TITLE
Support multiple JSON objects in a stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,17 @@ exports.parse = function (path) {
   stream.emit('data', this.value[this.key])
   }
 
+  parser._onToken = parser.onToken;
+
+  parser.onToken = function (token, value) {
+    parser._onToken(token, value);
+    if (this.stack.length === 0) {
+      if(!path)
+        stream.emit('data', stream.root)
+      stream.emit('root', stream.root, count)
+      count = 0;
+    }
+  }
 
   parser.onError = function (err) {
     stream.emit('error', err)
@@ -71,9 +82,6 @@ exports.parse = function (path) {
   stream.end = function (data) {
     if(data)
       stream.write(data)
-    if(!path)
-      stream.emit('data', stream.root)
-    stream.emit('root', stream.root, count)
     stream.emit('end')
   }
 

--- a/test/multiple_objects.js
+++ b/test/multiple_objects.js
@@ -1,0 +1,37 @@
+var fs = require ('fs');
+var net = require('net');
+var join = require('path').join;
+var file = join(__dirname, 'fixtures','all_npm.json');
+var it = require('it-is');
+var JSONStream = require('../');
+
+var str = fs.readFileSync(file);
+var expected = JSON.parse(str);
+
+var server = net.createServer(function(client) {
+    var root_calls = 0;
+    var data_calls = 0;
+    var parser = JSONStream.parse();
+    parser.on('root', function(root, count) {
+        ++ root_calls;
+    });
+
+    parser.on('data', function(data) {
+        ++ data_calls;
+        it(data).deepEqual(expected)
+    });
+
+    parser.on('end', function() {
+        console.error('END');
+        it(root_calls).equal(3);
+        it(data_calls).equal(3);
+        server.close();
+    });
+    client.pipe(parser);
+});
+server.listen(9999);
+
+var client = net.connect({ port : 9999 }, function() {
+    var msgs = [str, str, str].join('');
+    client.end(msgs);
+});


### PR DESCRIPTION
At the moment only one JSON object per stream is parsed. With this change a root event and/or a data event is emitted any time a JSON object is parsed without having to wait for the stream to end.
