### PR TITLE
Reset stream.root after emitting it

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,13 @@ exports.parse = function (path) {
   parser.onToken = function (token, value) {
     parser._onToken(token, value);
     if (this.stack.length === 0) {
-      if(!path)
-        stream.emit('data', stream.root)
-      stream.emit('root', stream.root, count)
-      count = 0;
+      if (stream.root) {
+        if(!path)
+          stream.emit('data', stream.root)
+        stream.emit('root', stream.root, count)
+        count = 0;
+        stream.root = null;
+      }
     }
   }
 

--- a/test/multiple_objects_error.js
+++ b/test/multiple_objects_error.js
@@ -1,0 +1,35 @@
+var fs = require ('fs');
+var net = require('net');
+var join = require('path').join;
+var file = join(__dirname, 'fixtures','all_npm.json');
+var it = require('it-is');
+var JSONStream = require('../');
+
+var str = fs.readFileSync(file);
+
+var server = net.createServer(function(client) {
+    var root_calls = 0;
+    var data_calls = 0;
+    var parser = JSONStream.parse();
+    parser.on('root', function(root, count) {
+        ++ root_calls;
+        it(root_calls).notEqual(2);
+    });
+
+    parser.on('error', function(err) {
+        console.log(err);
+        server.close();
+    });
+
+    parser.on('end', function() {
+        console.log('END');
+        server.close();
+    });
+    client.pipe(parser);
+});
+server.listen(9999);
+
+var client = net.connect({ port : 9999 }, function() {
+    var msgs = str + '}';
+    client.end(msgs);
+});


### PR DESCRIPTION
- This was causing the emission of incorrect objects after an error (see test case).
