### PR TITLE
Upgrade jsonparse in order to address issue #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/JSONStream.git"
   },
   "dependencies": {
-    "jsonparse": "0.0.1"
+    "jsonparse": "0.0.2"
   },
   "devDependencies": {
     "it-is": "~1",


### PR DESCRIPTION
[Issue #10: parser barfs on numbers in exponential notation](https://github.com/dominictarr/JSONStream/issues/10) is [supposed to be fixed by version 0.0.2 of jsonparse](https://github.com/creationix/jsonparse/pull/4):
