### PR TITLE
Check whether or not Buffer and Int32Array are present and support buf[index]

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,25 @@ var Parser = require('jsonparse')
 
 */
 
+/*
+
+  In order to use jsonparse we need something that supports buf[index]
+  so check what works in the current environment.
+
+*/
+
+var isSafeToUseBuffer =
+  ('undefined' !== typeof Buffer) &&
+  (new Buffer('X')[0] === 88)
+
+var isSafeToUseInt32Array =
+  ('undefined' !== typeof Int32Array) &&
+  function(){
+    var buf = new Int32Array(1)
+    buf[0] = 42
+    return buf[0] === 42
+  }()
+
 exports.parse = function (path) {
 
   var stream = new Stream()
@@ -72,12 +91,12 @@ exports.parse = function (path) {
   stream.writable = true
   stream.write = function (chunk) {
     if('string' === typeof chunk) {
-      if ('undefined' === typeof Buffer) {
+      if (isSafeToUseBuffer) {
+        chunk = new Buffer(chunk)
+      } else {
         var buf = new Array(chunk.length)
         for (var i = 0; i < chunk.length; i++) buf[i] = chunk.charCodeAt(i)
-        chunk = new Int32Array(buf)
-      } else {
-        chunk = new Buffer(chunk)
+        chunk = isSafeToUseInt32Array ? new Int32Array(buf) : buf
       }
     }
     parser.write(chunk)


### PR DESCRIPTION
As I mentioned in creationix/jsonparse#10 I've run into a problem with a combination of browserify/zombie where browserify's implementation of `Buffer` can't implement the `[]` operator which jsonparse makes use of. I guess the same will happen for other polyfills too.

This pull request intends to check that whatever is given to jsonparse supports `[]`, falling back to `Int32Array` and then `Array` if `Buffer` is either not available or won't work with jsonparse. The tests now pass using buffer-browserify's `Buffer` where they previously failed.

As you can probably tell I'm no JS expert - particularly when it comes to client-side stuff - so am prepared for ridicule/schooling as appropriate :grin:
