### PR TITLE
don't use buffer-browserify in browser since it doesn't work with jsonparse

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ exports.parse = function (path) {
   var parser = new Parser()
   var stream = through(function (chunk) {
     if('string' === typeof chunk) {
-      if ('undefined' === typeof Buffer) {
+      if (process.browser) {
         var buf = new Array(chunk.length)
         for (var i = 0; i < chunk.length; i++) buf[i] = chunk.charCodeAt(i)
         chunk = new Int32Array(buf)


### PR DESCRIPTION
as of browserifyv2 buffer-browserify automatically gets included so that means that the codepath being changed by this pull req changed so that JSONStream tried to use a fake `Buffer` with jsonparse. this unfortunately doesn't work. all this patch does it make it always use typed arrays (which work with jsonparse in the browser) when in the browser

also TODO is to make a simple + easy to run browser test for this lib
