### PR TITLE
Use version range for through dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "jsonparse": "0.0.5",
-    "through": "~2.2.7"
+    "through": ">=2.2.7 <3"
   },
   "devDependencies": {
     "it-is": "~1",


### PR DESCRIPTION
This reduces the size of installs with multiple `through` dependencies (read browserify).
I used `>=` and `<` to not break older npm installs with `^`.

My personal motivation is slightly different though: npm seems to have a bug in dedupe and this change would work around it (see https://github.com/npm/npm/issues/5025).
