### PR TITLE
Clarify licensing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "git://github.com/dominictarr/JSONStream.git"
   },
+  "license": "(MIT OR Apache-2.0)",
   "keywords": [
     "json",
     "stream",

--- a/readme.markdown
+++ b/readme.markdown
@@ -169,4 +169,4 @@ https://github.com/Floby/node-json-streams
 
 ## license
 
-MIT / APACHE2
+Dual-licensed under the MIT License or the Apache License, version 2.0


### PR DESCRIPTION
Kia ora, @dominictarr! Thanks so much for JSONStream.

This PR clarifies what I take it are the licensing terms for the package: "dual licensing" under [MIT](http://spdx.org/licenses/MIT) ~~and~~or [Apache 2.0](http://spdx.org/licenses/Apache-2.0), so users can pick between them. The commit also adds [an appropriate package.json property](https://docs.npmjs.com/files/package.json#license) for dual licensing.

Boolean license expressions, you say? Mad license science, says I!