### PR TITLE
added missing 'stream' variable declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,8 @@ exports.stringifyObject = function (op, sep, cl, indent) {
 
   //else, what ever you like
 
-  var first = true
+  var stream
+    , first = true
     , anyData = false
   stream = through(function (data) {
     anyData = true


### PR DESCRIPTION
While testing a version of our app which introduced a dependency on JSONStream module in production environment, I have bumped into this reference error.
_(Funny enough this did not come up on our staging farm which supposed to be identical to production, but hey what do I know apparently there is some discrepancies that I did not pick up.)_

Moving on... here is a truncated stack trace of this error:
> [ReferenceError: stream is not defined]
> ReferenceError: stream is not defined
>    at Object.exports.stringifyObject (/shared/projects/monkey-city/js/node_modules/JSONStream/index.js:193:10)
>    at Object.module.exports.jsonStreamToString (/shared/projects/monkey-city/js/monkey_city/stream_utils/index.js:17:27)
>    at /shared/projects/monkey-city/js/monkey_city/resources/link-cloud-blob.js:99:25

Adding a missing var declaration for 'stream' fixes it.
