### PR TITLE
Added emitPath option

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ exports.parse = function (path, map) {
     var i = 0 // iterates on path
     var j  = 0 // iterates on stack
     var emitKey = false;
+    var emitPath = false;
     while (i < path.length) {
       var key = path[i]
       var c
@@ -71,6 +72,7 @@ exports.parse = function (path, map) {
           return
         }
         emitKey = !!key.emitKey;
+        emitPath = !!key.emitPath;
         i++
       } else {
         i++
@@ -99,7 +101,14 @@ exports.parse = function (path, map) {
     var data = this.value[this.key]
     if(null != data)
       if(null != (data = map ? map(data, actualPath) : data)) {
-        data = emitKey ? { value: data, key: this.key } : data;
+        if (emitKey || emitPath) {
+          data = { value: data };
+          if (emitKey)
+            data["key"] = this.key;
+          if (emitPath)
+            data["path"] = actualPath;
+        }
+
         stream.queue(data)
       }
     delete this.value[this.key]

--- a/readme.markdown
+++ b/readme.markdown
@@ -104,6 +104,18 @@ stream.on('data', function(data) {
 
 ```
 
+You can also emit the path:
+
+``` js
+var stream = JSONStream.parse(['rows', true, 'doc', {emitPath: true}]) //rows, ANYTHING, doc, items in docs with keys
+
+stream.on('data', function(data) {
+  console.log('path:', data.path);
+  console.log('value:', data.value);
+});
+
+```
+
 ### recursive patterns (..)
 
 `JSONStream.parse('docs..value')` 

--- a/test/keys.js
+++ b/test/keys.js
@@ -39,6 +39,26 @@ test('keys via array', function(t) {
     assertFixtureKeys(stream, t);
 });
 
+test('path via array', function(t) {
+    var stream = JSONStream.parse(['obj',{emitPath: true}]);
+    
+    var paths = [];
+    var values = [];
+    stream.on('data', function(data) {
+        console.log(JSON.stringify(data));
+        paths.push(data.path);
+        values.push(data.value);
+    });
+
+    stream.on('end', function() {
+        t.deepEqual(paths, [['obj', 'one'], ['obj', 'two'], ['obj', 'three']]);
+        t.deepEqual(values, [1,2,3]);
+        t.end();
+    });
+    stream.write(JSON.stringify(fixture));
+    stream.end();
+});
+
 test('advanced keys', function(t) {
     var advanced = fs.readFileSync(couch_sample_file);
     var stream = JSONStream.parse(['rows', true, 'doc', {emitKey: true}]);


### PR DESCRIPTION
Hello,
This PR implements an option to emitPath as discussed in #101. 
The option works the same was as emitKey e.g. 
```
var stream = JSONStream.parse(['rows', true, 'doc', {emitPath: true}]) 
stream.on('data', function(data) {
  console.log('key:', data.path);
  console.log('value:', data.value);
});
```
Please let me know if anything needs changing. 
Thanks!

