### PR TITLE
bump jsonparse

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "parsing"
   ],
   "dependencies": {
-    "jsonparse": "^1.2.0",
+    "jsonparse": "^1.3.0",
     "through": ">=2.2.7 <3"
   },
   "devDependencies": {


### PR DESCRIPTION
Not necessary since 1.3.0 will be installed on new installations, but seems like it might be worth explicitly for people watching for changes.  1.3.0 has a big memory usage improvement for parsing long tokens.