### PR TITLE
Move header emit to before a row is parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,12 @@ exports.parse = function (path, map) {
       }
 
     }
+
+    // emit header
+    if (header) {
+      stream.emit('header', header);
+      header = false;
+    }
     if (j !== this.stack.length) return
 
     count ++
@@ -115,12 +121,6 @@ exports.parse = function (path, map) {
     for(var k in this.stack)
       if (!Object.isFrozen(this.stack[k]))
         this.stack[k].value = null
-
-    // emit header
-    if (header) {
-      stream.emit('header', header);
-      header = false;
-    }
   }
   parser._onToken = parser.onToken;
 

--- a/test/header_footer.js
+++ b/test/header_footer.js
@@ -38,6 +38,7 @@ parser.on('data', function (data) {
     value: {rev: it.typeof('string')},
     key:it.typeof('string')
   })
+  it(headerCalled).equal(1)
   parsed.push(data)
 })
 


### PR DESCRIPTION
Changed:
- moved the header#emit event to be above the first stream queue
- added a test to confirm the header event is emitted before the data