### PR TITLE
Handle jsonparse errors consistently

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ exports.parse = function (path, map) {
   }
 
   parser.onError = function (err) {
-    if(err.message.indexOf("at position") > -1)
+    if(err.message.indexOf("in state") > -1)
       err.message = "Invalid JSON (" + err.message + ")";
     stream.emit('error', err)
   }


### PR DESCRIPTION
closes #136 

I am not 100% sure if I like this. Overall the error checks are very fragile in case of `jsonparse` changing some wording, we would probably miss them. 

Also not this PR breaks code If someone relies on the unhandled error message structure.

We could add some test and and simulate all jsonparse errors to ensure every message gets wrapped correctly. What do you think?