### PR TITLE
Do not use the deprecated Buffer() constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 var Parser = require('jsonparse')
   , through = require('through')
 
+var bufferFrom = Buffer.from && Buffer.from !== Uint8Array.from
+
 /*
 
   the value of this.stack that creationix's jsonparse has is weird.
@@ -17,7 +19,7 @@ exports.parse = function (path, map) {
   var parser = new Parser()
   var stream = through(function (chunk) {
     if('string' === typeof chunk)
-      chunk = new Buffer(chunk)
+      chunk = bufferFrom ? Buffer.from(chunk) : new Buffer(chunk)
     parser.write(chunk)
   },
   function (data) {

--- a/test/parsejson.js
+++ b/test/parsejson.js
@@ -9,6 +9,9 @@ var r = Math.random()
   , p = new Parser()
   , assert = require('assert')  
   , times = 20
+  , bufferFrom = Buffer.from && Buffer.from !== Uint8Array.from
+  , str
+
 while (times --) {
 
   assert.equal(JSON.parse(JSON.stringify(r)), r, 'core JSON')
@@ -18,7 +21,8 @@ while (times --) {
     assert.equal(v,r)
   }
   console.error('correct', r)
-  p.write (new Buffer(JSON.stringify([r])))
+  str = JSON.stringify([r])
+  p.write (bufferFrom ? Buffer.from(str) : new Buffer(str))
 
 
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/605
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor